### PR TITLE
feat: prevent popups for links containing images in markdown files

### DIFF
--- a/content.js
+++ b/content.js
@@ -1072,6 +1072,11 @@ document.addEventListener("mouseover", (e) => {
   const link = e.target.closest('a[href*="/blob/"], a[href*="/tree/"]');
   if (!link || link === lastTarget) return;
 
+  // Skip if link contains an image (rendered images in markdown files) so this prevents showing popups for already-visible images but still allows popups for image files in the tree view
+  const containsImage = link.querySelector('img') !== null;
+  
+  if (containsImage) return;
+
   lastTarget = link;
   clearTimeout(hoverTimer);
 


### PR DESCRIPTION
This PR solves the issue of showing popups for markdown images, they already are shown in github then why do we want the popups for them (the popups for the images which are not shown, which are in the file tree, are still there)

solves a sub issue of #13 